### PR TITLE
update d3-tip dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "d3": "~3.5.2",
     "colorBrewer": "https://raw.githubusercontent.com/d3/d3/bower-metadata/lib/colorbrewer/colorbrewer.css",
-    "d3-tip": "0.6.7"
+    "d3-tip": "~0.6.8"
   },
   "resolutions": {
     "d3": "~3.5.2"


### PR DESCRIPTION
`d3-tip` is recently updated from `0.6.7` to two versions: `0.6.8` & `0.7.0`.
The `0.6.8` version solved its `d3` dependency problem which wrongly relied on exact version `d3 3.5.5` only, while the `0.7.0` version relies on `d3 v4` which is not supported by `circosJS` yet.