### PR TITLE
Bug Fix for Stack with direction='in'

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build --if-present
+    - run: npm test
+      env:
+        CI: true

--- a/src/tracks/Stack.js
+++ b/src/tracks/Stack.js
@@ -95,8 +95,7 @@ export default class Stack extends Track {
     if (this.conf.direction === 'in') {
       return [
         Math.max(this.conf.outerRadius - radialEnd, this.conf.innerRadius),
-         Math.min( this.conf.outerRadius - radialStart,this.conf.innerRadius)
-       
+        this.conf.outerRadius - radialStart
       ]
     }
 

--- a/src/tracks/Stack.js
+++ b/src/tracks/Stack.js
@@ -95,7 +95,8 @@ export default class Stack extends Track {
     if (this.conf.direction === 'in') {
       return [
         Math.max(this.conf.outerRadius - radialEnd, this.conf.innerRadius),
-        this.conf.outerRadius - radialStart
+         Math.min( this.conf.outerRadius - radialStart,this.conf.innerRadius)
+       
       ]
     }
 

--- a/src/tracks/Stack.js
+++ b/src/tracks/Stack.js
@@ -95,7 +95,8 @@ export default class Stack extends Track {
     if (this.conf.direction === 'in') {
       return [
         Math.max(this.conf.outerRadius - radialEnd, this.conf.innerRadius),
-        this.conf.outerRadius - radialStart
+          Math.min(   this.conf.outerRadius - radialStart, this.conf.innerRadius)
+     
       ]
     }
 

--- a/src/tracks/Stack.js
+++ b/src/tracks/Stack.js
@@ -95,7 +95,7 @@ export default class Stack extends Track {
     if (this.conf.direction === 'in') {
       return [
         Math.max(this.conf.outerRadius - radialEnd, this.conf.innerRadius),
-          Math.min(   this.conf.outerRadius - radialStart, this.conf.innerRadius)
+        Math.max(this.conf.outerRadius - radialStart,this.conf.innerRadius)
      
       ]
     }


### PR DESCRIPTION
There is no way to specify max. no of layers for stack. If there are too many overlapping regions and when we specify stack direction = 'in' or 'center' the stack layers are getting plotted outside the specified the inner and outer radius. But in case of direction ='out' the layers are getting hidden . Layers are not getting plotted outside the specified inner and outer radius in case direction = 'out'.
Please refer issue #81 

Change in Stack.js

   if (this.conf.direction === 'in') {
      return [
        Math.max(this.conf.outerRadius - radialEnd, this.conf.innerRadius),
        **Math.max(this.conf.outerRadius - radialStart,this.conf.innerRadius)**
        
      ]
    }
